### PR TITLE
Downloading many papers

### DIFF
--- a/pangaea/parser.py
+++ b/pangaea/parser.py
@@ -42,7 +42,7 @@ class Parser:
             dict: A dictionary containing the relevant information of a
                 single article.
         """
-        for event, elem in etree.iterparse(self.xml_file, events=('end',), tag='PubmedArticle'):
+        for event, elem in etree.iterparse(self.xml_file, events=('end',), tag='PubmedArticle', recover=True):
             current_article = {}
             medline_citation = elem.find('MedlineCitation')
             article = medline_citation.find('Article')


### PR DESCRIPTION
Due to limits added to the ESearch API, the download function appears to be limited to 10,000 papers.
For example, if I run `pangaea download --number 150000 "tp53"`, I get the error "The API did not return a list of IDs".

One solution to this is to download using the Entrez Direct's `esearch` and `efetch` tool, for example:
`esearch -db pubmed -sort Relevance -query "Interferon alpha PEGylation AND IFN" | efetch -format xml > papers.xml`
Then we can process with pangaea local: `pangaea local --output output.json papers.xml`.

However, some of the xml files that `efetch` returns seem to contain weird characters and I get the error: `TypeError: can't pickle lxml.etree._ListErrorLog objects`. 

The solution I have found is to add a recovery argument to the parser in `parse_papers`: `for event, elem in etree.iterparse(self.xml_file, events=('end',), tag='PubmedArticle', recover=True):`.
Adding this change to the code would allow pangaea local to process the xml outputs from the Entrez Direct tools.